### PR TITLE
Adds generation storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "http",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "language-tags",
  "local-channel",
  "log",
@@ -188,7 +188,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa",
+ "itoa 0.4.8",
  "language-tags",
  "log",
  "mime",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys",
 ]
@@ -1070,7 +1070,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1111,7 +1111,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1192,6 +1192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,9 +1229,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "local-channel"
@@ -1426,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -1620,18 +1626,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1912,12 +1918,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "indexmap",
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -1929,7 +1935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -2043,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7911b0031a0247af40095838002999c7a52fba29d9739e93326e71a5a1bc9d43"
+checksum = "692749de69603d81e016212199d73a2e14ee20e2def7d7914919e8db5d4d48b9"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2053,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec89bfaca8f7737439bad16d52b07f1ccd0730520d3bf6ae9d069fe4b641fb1"
+checksum = "518be6f6fff5ca76f985d434f9c37f3662af279642acf730388f271dff7b9016"
 dependencies = [
  "ahash",
  "atoi",
@@ -2077,7 +2083,7 @@ dependencies = [
  "hex",
  "hmac",
  "indexmap",
- "itoa",
+ "itoa 1.0.1",
  "libc",
  "log",
  "md-5",
@@ -2098,6 +2104,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
+ "uuid",
  "webpki",
  "webpki-roots",
  "whoami",
@@ -2105,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584866c833511b1a152e87a7ee20dee2739746f60c858b3c5209150bc4b466f5"
+checksum = "38e45140529cf1f90a5e1c2e561500ca345821a1c513652c8f486bbf07407cc8"
 dependencies = [
  "dotenv",
  "either",
@@ -2127,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1bd069de53442e7a320f525a6d4deb8bb0621ac7a55f7eccbc2b58b57f43d0"
+checksum = "8061cbaa91ee75041514f67a09398c65a64efed72c90151ecd47593bad53da99"
 dependencies = [
  "actix-rt",
  "once_cell",
@@ -2225,9 +2232,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2298,7 +2305,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "libc",
 ]
 
@@ -2561,6 +2568,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-sqlx = { version = "0.5.9", features = [ "postgres", "runtime-actix-rustls", "macros", "migrate", "offline" ] }
+sqlx = { version = "0.5.10", features = [ "postgres", "runtime-actix-rustls", "macros", "migrate", "offline", "uuid" ] }
 actix-web="4.0.0-beta.15"
 async-trait = "0.1.52"
 async-graphql="3.0.17"

--- a/migrations/20220202225415_generation_result_storage.down.sql
+++ b/migrations/20220202225415_generation_result_storage.down.sql
@@ -1,0 +1,8 @@
+-- Add down migration script here
+DROP TABLE
+  generated_phrase_speech,
+  generated_phrase;
+
+DROP TYPE
+  lang,
+  gender;

--- a/migrations/20220202225415_generation_result_storage.up.sql
+++ b/migrations/20220202225415_generation_result_storage.up.sql
@@ -1,0 +1,21 @@
+-- Add up migration script here
+CREATE TABLE generated_phrase (
+  id uuid primary key not null default gen_random_uuid(),
+  content text not null
+);
+CREATE UNIQUE INDEX idx_generated_phrase_uniqueness ON generated_phrase (content);
+CREATE INDEX idx_generated_phrase_lookup ON generated_phrase (content);
+
+create type lang AS ENUM ('ita');
+create type gender AS ENUM ('male', 'female');
+
+CREATE TABLE generated_phrase_speech (
+  id serial primary key not null,
+  generated_phrase uuid not null,
+  lang lang not null,
+  gender gender not null,
+  url text not null,
+  foreign key (generated_phrase) references generated_phrase (id)
+);
+CREATE UNIQUE INDEX idx_generated_phrase_speech_uniqueness ON generated_phrase_speech (generated_phrase, lang, gender);
+CREATE INDEX idx_generated_phrase_speech_lookup ON generated_phrase_speech (generated_phrase, lang, gender);

--- a/src/app_core/errors/mod.rs
+++ b/src/app_core/errors/mod.rs
@@ -21,6 +21,12 @@ impl AppError {
     pub fn for_upload(error: reqwest::Error) -> Self {
         UploadError::from(error).into()
     }
+    pub fn for_upload_in_sql(error: sqlx::Error) -> Self {
+        UploadError::from(error).into()
+    }
+    pub fn for_upload_in_sql_uuid(error: sqlx::types::uuid::Error) -> Self {
+        UploadError::from(error).into()
+    }
     pub fn for_generation_in_sql(error: sqlx::Error) -> Self {
         GenerationError::from(error).into()
     }
@@ -69,6 +75,10 @@ impl AppError {
 pub enum UploadError {
     #[error("Server had problems connecting to its dependencies.")]
     HttpFailed(#[from] HttpError),
+    #[error("DB Error, {0}")]
+    DBFailed(String),
+    #[error("DB UUID parsing failed, {0}")]
+    UuidNotParsed(String),
 }
 
 #[derive(Error, Debug, Clone)]
@@ -96,6 +106,18 @@ impl From<sqlx::Error> for GenerationError {
 impl From<sqlx::Error> for InfrastructureError {
     fn from(e: Error) -> Self {
         Self::DBConnectionsUnavailable(format!("{e}"))
+    }
+}
+
+impl From<sqlx::Error> for UploadError {
+    fn from(e: Error) -> Self {
+        Self::DBFailed(format!("{e}"))
+    }
+}
+
+impl From<sqlx::types::uuid::Error> for UploadError {
+    fn from(e: sqlx::types::uuid::Error) -> Self {
+        Self::DBFailed(format!("{e}"))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,15 @@ async fn main() -> std::io::Result<()> {
             root_url: Url::parse(&tts_wrapper_root).unwrap(),
         },
     )));
-    let generator = PhraseGenerator::new(Arc::new(pool));
-    let core = Arc::new(AppCore::new(Arc::new(uploader), Arc::new(generator)));
+
+    //TODO: this is a smell. Arc<Pool> can be put only once if I happen to define a "DAO"
+    let arc_pool = Arc::new(pool);
+    let generator = PhraseGenerator::new(arc_pool.clone());
+    let core = Arc::new(AppCore::new(
+        Arc::new(uploader),
+        Arc::new(generator),
+        arc_pool,
+    ));
 
     let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
         .data(core.clone()) //For GQL field async resolvers through Context

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,13 +25,16 @@ async fn main() -> std::io::Result<()> {
     let tts_wrapper_root =
         std::env::var("TTS_WRAPPER_URL").unwrap_or_else(|_| "http://localhost:8080".to_owned());
 
+    let db_connection_string = std::env::var("DB_CONNECTION_STRING")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost:49153/postgres".to_owned());
+
     info!("Connecting to TTS wrapper at: {}", tts_wrapper_root);
 
-    info!("Connecting to DB at: postgres://postgres:password@localhost:49156/postgres");
+    info!("Connecting to DB at: EH? VOLEVIH!");
 
     let pool = PgPoolOptions::new()
         .max_connections(8)
-        .connect("postgres://postgres:password@localhost:49156/postgres")
+        .connect(db_connection_string.as_str())
         .await
         .expect("Postgres connection failed!");
 

--- a/src/served/types/graphql.rs
+++ b/src/served/types/graphql.rs
@@ -2,6 +2,7 @@ use async_graphql::{Context, Enum, InputObject, Object};
 
 use std::sync::Arc;
 
+use crate::app_core::errors::AppError;
 use crate::app_core::{AppCore, AppResult, SpeechGenerationOptions};
 
 pub struct QueryRoot;
@@ -17,15 +18,36 @@ pub struct Voice {
     pub gender: Gender,
 }
 
-#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+#[derive(Enum, Copy, Clone, Eq, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "lang")] // May also be the name of a user defined enum type
+#[sqlx(rename_all = "lowercase")] // similar to serde rename_all
 pub enum Language {
-    Italian,
+    Ita,
 }
 
-#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+impl ToString for Language {
+    fn to_string(&self) -> String {
+        match self {
+            Language::Ita => "ita".to_string(),
+        }
+    }
+}
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "gender")] // May also be the name of a user defined enum type
+#[sqlx(rename_all = "lowercase")] // similar to serde rename_all
 pub enum Gender {
     Male,
     Female,
+}
+
+impl ToString for Gender {
+    fn to_string(&self) -> String {
+        match self {
+            Gender::Male => "male".to_owned(),
+            Gender::Female => "female".to_owned(),
+        }
+    }
 }
 
 #[Object]
@@ -55,15 +77,48 @@ impl Speech {
         &self.text
     }
 
+    //TODO: refactor this crap
     pub async fn audio_url<'c>(&self, ctx: &Context<'c>, voice: Voice) -> AppResult<String> {
-        let uploader = ctx.data_unchecked::<Arc<AppCore>>().uploader();
         let text = &self.text;
-        uploader
-            .upload(crate::app_core::types::upload::Speech {
-                is_male: matches!(voice.gender, Gender::Male),
-                text: text.clone(),
-            })
+        let id =
+            sqlx::types::Uuid::parse_str(&self.id).map_err(AppError::for_upload_in_sql_uuid)?;
+        let uploader = ctx.data_unchecked::<Arc<AppCore>>().uploader();
+        let mut transaction = ctx
+            .data_unchecked::<Arc<AppCore>>()
+            .pool()
+            .begin()
             .await
-            .map(|res| res.url.to_string())
+            .map_err(AppError::for_upload_in_sql)?;
+
+        // See: https://docs.rs/sqlx/0.4.2/sqlx/macro.query.html#type-overrides-bind-parameters-postgres-only
+        if let Some(url) = sqlx::query!(
+            "SELECT url FROM generated_phrase_speech WHERE generated_phrase = $1 AND lang = $2 AND gender = $3",
+            id as sqlx::types::Uuid, voice.language as _, voice.gender as _
+        )
+        .fetch_optional(&mut transaction)
+        .await
+        .map_err(AppError::for_upload_in_sql)?
+            .map(|res| res.url) {
+            Ok(url)
+        } else {
+            let url = uploader
+                .upload(crate::app_core::types::upload::Speech {
+                    is_male: matches!(voice.gender, Gender::Male),
+                    text: text.clone(),
+                })
+                .await
+                .map(|res| res.url.to_string())?;
+
+            sqlx::query!(
+                "INSERT INTO generated_phrase_speech (generated_phrase, lang, gender, url) VALUES ($1, $2, $3, $4)",
+                id as _, voice.language as _, voice.gender as _, &url as _
+            ).execute(&mut transaction)
+                .await
+                .map_err(AppError::for_upload_in_sql)?;
+
+            transaction.commit().await.map_err(AppError::for_upload_in_sql)?;
+
+            Ok(url)
+        }
     }
 }


### PR DESCRIPTION
Vomiting code for:
- storing generated phrases speech audio URLs in DB in order to reduce the stress towards `tts-rest-wrapper`;
- storing generated texts in order to reduce the stress towards the DB query;
- limiting the number (still hardcoded...) of generated phrases via RNG and likelihood inverse to the quantity of generated phrases

Warning: this PR is making the code less readable and unit testable. Rework is needed in order to keep it reasonable maintainable.